### PR TITLE
fix(#3): sync toolbar tool selection when annotation is selected

### DIFF
--- a/Sources/ScreenshotPlus/Controllers/ToolbarController.swift
+++ b/Sources/ScreenshotPlus/Controllers/ToolbarController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import Combine
 
 func createLineWidthImage(width: CGFloat, color: NSColor, size: NSSize = NSSize(width: 40, height: 16)) -> NSImage {
     let image = NSImage(size: size)
@@ -22,6 +23,12 @@ class ToolbarController: NSObject, NSToolbarDelegate, NSPopoverDelegate, NSToolb
     private var undoItem: NSToolbarItem?
     private var redoItem: NSToolbarItem?
     private weak var toolbar: NSToolbar?
+    private var cancellables = Set<AnyCancellable>()
+    private let toolOrder: [DrawingTool] = [.select, .rectangle, .oval, .line, .arrow, .pen, .text]
+
+    var currentToolsGroupIndex: Int {
+        toolsGroup?.selectedIndex ?? -1
+    }
 
     private let itemIdentifiers: [NSToolbarItem.Identifier] = [
         .init("padding"),
@@ -39,6 +46,21 @@ class ToolbarController: NSObject, NSToolbarDelegate, NSPopoverDelegate, NSToolb
     init(canvasState: CanvasState, windowState: AnnotationWindowState) {
         self.canvasState = canvasState
         self.windowState = windowState
+        super.init()
+        setupToolObserver()
+    }
+
+    private func setupToolObserver() {
+        canvasState.$currentTool
+            .dropFirst() // Skip initial value, we set it when creating the group
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newTool in
+                guard let self = self, let group = self.toolsGroup else { return }
+                if let index = self.toolOrder.firstIndex(of: newTool) {
+                    group.selectedIndex = index
+                }
+            }
+            .store(in: &cancellables)
     }
 
     func setToolbar(_ toolbar: NSToolbar) {
@@ -108,7 +130,6 @@ class ToolbarController: NSObject, NSToolbarDelegate, NSPopoverDelegate, NSToolb
                 group.subitems[index].toolTip = tool.2
             }
 
-            let toolOrder: [DrawingTool] = [.select, .rectangle, .oval, .line, .arrow, .pen, .text]
             group.selectedIndex = toolOrder.firstIndex(of: canvasState.currentTool) ?? 1
 
             group.label = "Tools"
@@ -149,10 +170,9 @@ class ToolbarController: NSObject, NSToolbarDelegate, NSPopoverDelegate, NSToolb
     }
 
     @objc private func toolGroupChanged(_ sender: NSToolbarItemGroup) {
-        let tools: [DrawingTool] = [.select, .rectangle, .oval, .line, .arrow, .pen, .text]
         let index = sender.selectedIndex
-        if index >= 0 && index < tools.count {
-            canvasState.currentTool = tools[index]
+        if index >= 0 && index < toolOrder.count {
+            canvasState.currentTool = toolOrder[index]
         }
     }
 

--- a/Sources/ScreenshotPlus/Models/Annotation.swift
+++ b/Sources/ScreenshotPlus/Models/Annotation.swift
@@ -9,6 +9,17 @@ enum AnnotationType: Equatable {
     case arrow
     case pen
     case text
+
+    var correspondingTool: DrawingTool {
+        switch self {
+        case .rectangle: return .rectangle
+        case .oval: return .oval
+        case .line: return .line
+        case .arrow: return .arrow
+        case .pen: return .pen
+        case .text: return .text
+        }
+    }
 }
 
 enum TextAlignment: String, CaseIterable {

--- a/Sources/ScreenshotPlus/Models/CanvasState.swift
+++ b/Sources/ScreenshotPlus/Models/CanvasState.swift
@@ -246,6 +246,11 @@ final class CanvasState: ObservableObject {
         selectedAnnotationIds.contains(annotation.id)
     }
 
+    func selectAnnotation(_ annotation: Annotation) {
+        selectedAnnotationIds = [annotation.id]
+        currentTool = annotation.type.correspondingTool
+    }
+
     func updateSelectedAnnotations(_ transform: (inout Annotation) -> Void) {
         for id in selectedAnnotationIds {
             if let index = annotations.firstIndex(where: { $0.id == id }) {

--- a/Sources/ScreenshotPlus/Models/CanvasState.swift
+++ b/Sources/ScreenshotPlus/Models/CanvasState.swift
@@ -246,6 +246,7 @@ final class CanvasState: ObservableObject {
         selectedAnnotationIds.contains(annotation.id)
     }
 
+    /// Selects the annotation and updates the current tool to match its type.
     func selectAnnotation(_ annotation: Annotation) {
         selectedAnnotationIds = [annotation.id]
         currentTool = annotation.type.correspondingTool

--- a/Sources/ScreenshotPlus/Views/DrawingCanvasView.swift
+++ b/Sources/ScreenshotPlus/Views/DrawingCanvasView.swift
@@ -285,7 +285,7 @@ struct DrawingCanvasView: View {
 
             // Check if clicking on an unselected annotation to select it (any tool)
             if let annotation = hitTestAnnotation(screenPoint: screenStart) {
-                canvasState.selectedAnnotationIds = [annotation.id]
+                canvasState.selectAnnotation(annotation)
                 canvasState.saveState()
                 dragMode = .moving
                 originalAnnotation = annotation

--- a/Tests/ScreenshotPlusTests/AnnotationTypeExtensionsTests.swift
+++ b/Tests/ScreenshotPlusTests/AnnotationTypeExtensionsTests.swift
@@ -52,4 +52,14 @@ struct AnnotationTypeExtensionsTests {
         #expect(oval.canBeFilled == true)
         #expect(line.canBeFilled == false)
     }
+
+    @Test("correspondingTool returns matching DrawingTool for each AnnotationType")
+    func correspondingToolMapsCorrectly() {
+        #expect(AnnotationType.rectangle.correspondingTool == .rectangle)
+        #expect(AnnotationType.oval.correspondingTool == .oval)
+        #expect(AnnotationType.line.correspondingTool == .line)
+        #expect(AnnotationType.arrow.correspondingTool == .arrow)
+        #expect(AnnotationType.pen.correspondingTool == .pen)
+        #expect(AnnotationType.text.correspondingTool == .text)
+    }
 }

--- a/Tests/ScreenshotPlusTests/CanvasStateSettingsTests.swift
+++ b/Tests/ScreenshotPlusTests/CanvasStateSettingsTests.swift
@@ -34,4 +34,24 @@ struct CanvasStateSettingsTests {
         #expect(canvasState.currentTool == .arrow)
         #expect(canvasState.textFontSize == 24.0)
     }
+
+    @Test("Selecting annotation updates currentTool to match annotation type")
+    func selectAnnotationUpdatesCurrentTool() {
+        let canvasState = CanvasState()
+        canvasState.currentTool = .pen
+
+        let rectangleAnnotation = Annotation(
+            type: .rectangle,
+            startPoint: .zero,
+            endPoint: CGPoint(x: 100, y: 100),
+            strokeColor: .red,
+            strokeWidth: 2
+        )
+        canvasState.annotations.append(rectangleAnnotation)
+
+        canvasState.selectAnnotation(rectangleAnnotation)
+
+        #expect(canvasState.selectedAnnotationIds.contains(rectangleAnnotation.id))
+        #expect(canvasState.currentTool == .rectangle)
+    }
 }

--- a/Tests/ScreenshotPlusTests/ToolbarControllerTests.swift
+++ b/Tests/ScreenshotPlusTests/ToolbarControllerTests.swift
@@ -15,4 +15,31 @@ struct ToolbarControllerTests {
 
         #expect(!identifiers.isEmpty)
     }
+
+    @Test("ToolbarController syncs selectedIndex when currentTool changes")
+    func syncToolbarWhenCurrentToolChanges() async {
+        let canvasState = CanvasState()
+        canvasState.currentTool = .rectangle
+        let windowState = AnnotationWindowState(imageURL: URL(fileURLWithPath: "/tmp/test.png"))
+        let controller = ToolbarController(canvasState: canvasState, windowState: windowState)
+
+        let toolbar = NSToolbar(identifier: "TestToolbar")
+        toolbar.delegate = controller
+        controller.setToolbar(toolbar)
+
+        // Force toolbar to create items
+        _ = controller.toolbar(toolbar, itemForItemIdentifier: .init("toolsGroup"), willBeInsertedIntoToolbar: true)
+
+        // Verify initial state
+        #expect(controller.currentToolsGroupIndex == 1) // rectangle is at index 1
+
+        // Change currentTool programmatically
+        canvasState.currentTool = .oval
+
+        // Wait for main queue to process the Combine update
+        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // Toolbar should sync
+        #expect(controller.currentToolsGroupIndex == 2) // oval is at index 2
+    }
 }


### PR DESCRIPTION
## References

- Closes #3

## Summary

- Add correspondingTool property to AnnotationType for mapping annotation types to drawing tools
- Add selectAnnotation method to CanvasState that selects an annotation and updates the current tool
- Add Combine subscription in ToolbarController to sync toolbar UI when currentTool changes programmatically
- Update DrawingCanvasView to use the new selectAnnotation method

When a user clicks on an existing annotation, the toolbar now correctly highlights the corresponding tool type.

## Test Plan

- [x] Unit tests pass (79 tests)
- [x] correspondingTool maps all annotation types correctly
- [x] selectAnnotation updates both selection and current tool
- [x] Toolbar syncs when currentTool changes programmatically