### PR TITLE
fix(#5): sync design settings when annotation is selected

### DIFF
--- a/Sources/ScreenshotPlus/Models/CanvasState.swift
+++ b/Sources/ScreenshotPlus/Models/CanvasState.swift
@@ -253,6 +253,19 @@ final class CanvasState: ObservableObject {
         strokeColor = annotation.strokeColor
         strokeWidth = annotation.strokeWidth
         fillShapes = annotation.isFilled
+
+        // Sync text-specific settings for text annotations
+        if annotation.type == .text {
+            textFontSize = annotation.fontSize
+            textFontName = annotation.fontName
+            textAlignment = annotation.textAlignment
+            textBackgroundColor = annotation.textBackgroundColor
+            textBackgroundPaddingTop = annotation.textBackgroundPaddingTop
+            textBackgroundPaddingRight = annotation.textBackgroundPaddingRight
+            textBackgroundPaddingBottom = annotation.textBackgroundPaddingBottom
+            textBackgroundPaddingLeft = annotation.textBackgroundPaddingLeft
+            textBackgroundCornerRadius = annotation.textBackgroundCornerRadius
+        }
     }
 
     func updateSelectedAnnotations(_ transform: (inout Annotation) -> Void) {

--- a/Sources/ScreenshotPlus/Models/CanvasState.swift
+++ b/Sources/ScreenshotPlus/Models/CanvasState.swift
@@ -246,10 +246,13 @@ final class CanvasState: ObservableObject {
         selectedAnnotationIds.contains(annotation.id)
     }
 
-    /// Selects the annotation and updates the current tool to match its type.
+    /// Selects the annotation and updates the current tool and design settings to match.
     func selectAnnotation(_ annotation: Annotation) {
         selectedAnnotationIds = [annotation.id]
         currentTool = annotation.type.correspondingTool
+        strokeColor = annotation.strokeColor
+        strokeWidth = annotation.strokeWidth
+        fillShapes = annotation.isFilled
     }
 
     func updateSelectedAnnotations(_ transform: (inout Annotation) -> Void) {

--- a/Tests/ScreenshotPlusTests/CanvasStateSettingsTests.swift
+++ b/Tests/ScreenshotPlusTests/CanvasStateSettingsTests.swift
@@ -54,4 +54,28 @@ struct CanvasStateSettingsTests {
         #expect(canvasState.selectedAnnotationIds.contains(rectangleAnnotation.id))
         #expect(canvasState.currentTool == .rectangle)
     }
+
+    @Test("Selecting annotation updates design settings to match annotation")
+    func selectAnnotationUpdatesDesignSettings() {
+        let canvasState = CanvasState()
+        canvasState.strokeColor = .blue
+        canvasState.strokeWidth = 2.0
+        canvasState.fillShapes = false
+
+        var annotation = Annotation(
+            type: .rectangle,
+            startPoint: .zero,
+            endPoint: CGPoint(x: 100, y: 100),
+            strokeColor: .red,
+            strokeWidth: 4.0
+        )
+        annotation.isFilled = true
+        canvasState.annotations.append(annotation)
+
+        canvasState.selectAnnotation(annotation)
+
+        #expect(canvasState.strokeColor == .red)
+        #expect(canvasState.strokeWidth == 4.0)
+        #expect(canvasState.fillShapes == true)
+    }
 }

--- a/Tests/ScreenshotPlusTests/CanvasStateSettingsTests.swift
+++ b/Tests/ScreenshotPlusTests/CanvasStateSettingsTests.swift
@@ -78,4 +78,33 @@ struct CanvasStateSettingsTests {
         #expect(canvasState.strokeWidth == 4.0)
         #expect(canvasState.fillShapes == true)
     }
+
+    @Test("Selecting text annotation updates text-specific settings")
+    func selectTextAnnotationUpdatesTextSettings() {
+        let canvasState = CanvasState()
+        canvasState.textFontSize = 16
+        canvasState.textFontName = "System"
+        canvasState.textAlignment = .left
+        canvasState.textBackgroundColor = nil
+
+        var textAnnotation = Annotation(
+            type: .text,
+            startPoint: .zero,
+            endPoint: .zero,
+            strokeColor: .red,
+            strokeWidth: 2
+        )
+        textAnnotation.fontSize = 24
+        textAnnotation.fontName = "Helvetica"
+        textAnnotation.textAlignment = .center
+        textAnnotation.textBackgroundColor = .yellow
+        canvasState.annotations.append(textAnnotation)
+
+        canvasState.selectAnnotation(textAnnotation)
+
+        #expect(canvasState.textFontSize == 24)
+        #expect(canvasState.textFontName == "Helvetica")
+        #expect(canvasState.textAlignment == .center)
+        #expect(canvasState.textBackgroundColor == .yellow)
+    }
 }


### PR DESCRIPTION
## References

- Closes #5

## Summary

- Extend `selectAnnotation()` to update design settings (strokeColor, strokeWidth, fillShapes) when selecting any annotation
- For text annotations, also sync text-specific properties (fontSize, fontName, textAlignment, textBackgroundColor, padding, cornerRadius)

When a user selects an existing annotation, the settings panel now reflects that annotation's properties, allowing intuitive editing.

## Test Plan

- [x] Unit tests pass (81 tests)
- [x] Selecting a shape annotation updates stroke/fill settings
- [x] Selecting a text annotation updates font and text background settings
- [x] Settings panel reflects selected annotation properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)