### PR TITLE
fix(#9): build Universal Binary for Intel and Apple Silicon support

### DIFF
--- a/Sources/ScreenshotPlus/App/AppConfig.swift
+++ b/Sources/ScreenshotPlus/App/AppConfig.swift
@@ -2,6 +2,6 @@ import Foundation
 
 enum AppConfig {
     static let appName = "Screenshot+"
-    static let version = "1.0.10"
-    static let build = "11"
+    static let version = "1.0.11"
+    static let build = "12"
 }

--- a/Sources/ScreenshotPlus/Info.plist
+++ b/Sources/ScreenshotPlus/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.screenshotplus.app</string>
     <key>CFBundleVersion</key>
-    <string>11</string>
+    <string>12</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.10</string>
+    <string>1.0.11</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -e
 APP_NAME="Screenshot+"
 BUNDLE_ID="com.screenshotplus.app"
 VERSION="1.0.0"
-BUILD_DIR=".build/release"
+BUILD_DIR=".build/apple/Products/Release"
 APP_BUNDLE="$APP_NAME.app"
 DIST_DIR="dist"
 DMG_NAME="$APP_NAME.dmg"
@@ -13,8 +13,8 @@ DMG_RW="$DIST_DIR/temp.dmg"
 
 echo "Building $APP_NAME v$VERSION..."
 
-# Build for release
-swift build -c release
+# Build Universal Binary for both Intel (x86_64) and Apple Silicon (arm64)
+swift build -c release --arch arm64 --arch x86_64
 
 # Create dist directory
 rm -rf "$DIST_DIR"


### PR DESCRIPTION
## References

- Closes #9

## Summary

Updates the build script to create a Universal Binary that supports both Intel (x86_64) and Apple Silicon (arm64) Macs. Previously, the app was built only for arm64, which caused installation failures on Intel Macs.

**Changes:**
- Updated `swift build` command to compile for both architectures using `--arch arm64 --arch x86_64`
- Updated build output path to the correct location for universal binaries (`.build/apple/Products/Release`)

**Verified:**
- `lipo -info` confirms the resulting binary contains both `x86_64` and `arm64` architectures

## Test Plan

- [x] Build produces Universal Binary (verified with `lipo -info`)
- [x] Manual testing completed on Apple Silicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)